### PR TITLE
Add param payment_method to Ogone_OrderStandard::start()

### DIFF
--- a/src/OrderStandard/Gateway.php
+++ b/src/OrderStandard/Gateway.php
@@ -50,7 +50,7 @@ class Pronamic_WP_Pay_Gateways_Ogone_OrderStandard_Gateway extends Pronamic_WP_P
 	 * @param Pronamic_Pay_PaymentDataInterface $data
 	 * @see Pronamic_WP_Pay_Gateway::start()
 	 */
-	public function start( Pronamic_Pay_PaymentDataInterface $data, Pronamic_Pay_Payment $payment ) {
+	public function start( Pronamic_Pay_PaymentDataInterface $data, Pronamic_Pay_Payment $payment, $payment_method = null ) {
 		$payment->set_action_url( $this->client->get_payment_server_url() );
 
 		$ogone_data = $this->client->get_data();


### PR DESCRIPTION
Make `Ogone_OrderStandard::start()` compatible with `Pronamic_WP_Pay_Gateway` abstract. Incompatibility causes `Strict Standards` warning.